### PR TITLE
Basic support for cutscene pages

### DIFF
--- a/lib/playground_book_lint/chapter_manifest_linter.rb
+++ b/lib/playground_book_lint/chapter_manifest_linter.rb
@@ -1,13 +1,15 @@
 require 'playground_book_lint/manifest_linter'
 require 'playground_book_lint/page_linter'
+require 'playground_book_lint/cutscene_page_linter'
 
 module PlaygroundBookLint
   # A linter for verifying the contents of a chapter's Manifest.plist
   class ChapterManifestLinter < ManifestLinter
-    attr_accessor :page_linter
+    attr_accessor :page_linter, :cutscene_page_linter
 
-    def initialize(page_linter = PageLinter.new)
+    def initialize(page_linter = PageLinter.new, cutscene_page_linter = CutscenePageLinter.new)
       @page_linter = page_linter
+      @cutscene_page_linter = cutscene_page_linter
     end
 
     def lint
@@ -19,10 +21,17 @@ module PlaygroundBookLint
         # All pages exist inside the /Pages subdirectory, we need to chdir to there first.
         Dir.chdir PAGES_DIRECTORY_NAME do
           fail_lint "Chapter page directory #{page_directory_name} missing in #{Dir.pwd}" unless Dir.exist?(page_directory_name)
+          lint_page page_directory_name
+        end
+      end
+    end
 
-          Dir.chdir page_directory_name do
-            page_linter.lint
-          end
+    def lint_page(page_directory_name)
+      Dir.chdir page_directory_name do
+        if page_directory_name =~ /.+\.playgroundpage$/
+          page_linter.lint
+        elsif page_directory_name =~ /.+\.cutscenepage$/
+          cutscene_page_linter.lint
         end
       end
     end

--- a/lib/playground_book_lint/cutscene_page_linter.rb
+++ b/lib/playground_book_lint/cutscene_page_linter.rb
@@ -1,10 +1,17 @@
 require 'playground_book_lint/abstract_linter'
+require 'playground_book_lint/cutscene_page_manifest_linter'
 
 module PlaygroundBookLint
   # A linter for verifying cutscene pages
   class CutscenePageLinter < AbstractLinter
+    attr_accessor :cutscene_page_manifest_linter
+
+    def initialize(cutscene_page_manifest_linter = CutscenePageManifestLinter.new)
+      @cutscene_page_manifest_linter = cutscene_page_manifest_linter
+    end
+
     def lint
-      # TODO: Lint the cutscene page manifest here
+      cutscene_page_manifest_linter.lint
     end
   end
 end

--- a/lib/playground_book_lint/cutscene_page_linter.rb
+++ b/lib/playground_book_lint/cutscene_page_linter.rb
@@ -1,0 +1,10 @@
+require 'playground_book_lint/abstract_linter'
+
+module PlaygroundBookLint
+  # A linter for verifying cutscene pages
+  class CutscenePageLinter < AbstractLinter
+    def lint
+      # TODO: Lint the cutscene page manifest here
+    end
+  end
+end

--- a/lib/playground_book_lint/cutscene_page_manifest_linter.rb
+++ b/lib/playground_book_lint/cutscene_page_manifest_linter.rb
@@ -1,0 +1,6 @@
+require 'playground_book_lint/manifest_linter'
+
+module PlaygroundBookLint
+  class CutscenePageManifestLinter < ManifestLinter
+  end
+end

--- a/spec/playground_book_lint/chapter_manifest_linter_spec.rb
+++ b/spec/playground_book_lint/chapter_manifest_linter_spec.rb
@@ -5,7 +5,7 @@ module PlaygroundBookLint
     include FakeFS::SpecHelpers
     let(:chapter_manifest_linter) { ChapterManifestLinter.new(page_linter) }
     let(:page_linter) { double(PageLinter) }
-    let!(:page_directory_name) { 'test_page_directory_name' }
+    let!(:page_directory_name) { 'test.playgroundpage' }
 
     it 'fails if no Pages defined in Manifest' do
       FakeFS do

--- a/spec/playground_book_lint/cutscene_page_linter_spec.rb
+++ b/spec/playground_book_lint/cutscene_page_linter_spec.rb
@@ -1,0 +1,14 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module PlaygroundBookLint
+  describe CutscenePageLinter do
+    include FakeFS::SpecHelpers
+    let(:cutscene_page_linter) { CutscenePageLinter.new(cutscene_page_manifest_linter) }
+    let(:cutscene_page_manifest_linter) { double(CutscenePageManifestLinter) }
+
+    it 'passes through to cutscene_page_manifest_linter' do
+      expect(cutscene_page_manifest_linter).to receive(:lint)
+      expect { cutscene_page_linter.lint }.to_not raise_error
+    end
+  end
+end

--- a/spec/playground_book_lint/cutscene_page_manifest_linter_spec.rb
+++ b/spec/playground_book_lint/cutscene_page_manifest_linter_spec.rb
@@ -1,0 +1,16 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module PlaygroundBookLint
+  describe CutscenePageManifestLinter do
+    include FakeFS::SpecHelpers
+    let(:cutscene_page_manifest_linter) { CutscenePageManifestLinter.new }
+
+    it 'does not fail' do
+      FakeFS do
+        plist = { 'Name' => 'Test Page' }.to_plist
+        File.open('Manifest.plist', 'w') { |f| f.write(plist) }
+        expect { cutscene_page_manifest_linter.lint }.to_not raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fixes #9 and adds very basic support for cutscene pages. In the future we'll probably want to expand this to, for example, ensure that the cutscene page's manifest points to an existing HTML file. For now though, this basic scaffolding resolves erroneous warnings when linting a playground book containing cutscene pages.