### PR TITLE
Check for valid LiveViewMode values

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ gem 'prettybacon'
 gem 'fakefs'
 gem 'rubocop', '~> 0.41.2', require: false
 
+require 'pp' # https://github.com/defunkt/fakefs/issues/99
 gemspec

--- a/lib/playground_book_lint/page_manifest_linter.rb
+++ b/lib/playground_book_lint/page_manifest_linter.rb
@@ -4,7 +4,7 @@ require 'playground_book_lint/manifest_linter'
 module PlaygroundBookLint
   # A linter for verifying the contents of a page's Manifest.plist
   class PageManifestLinter < ManifestLinter
-    SUPPORTED_LIVE_VIEW_MODES = ['VisibleByDefault', 'HiddenByDefault']
+    SUPPORTED_LIVE_VIEW_MODES = %w(VisibleByDefault HiddenByDefault).freeze
 
     def lint
       super()

--- a/lib/playground_book_lint/page_manifest_linter.rb
+++ b/lib/playground_book_lint/page_manifest_linter.rb
@@ -4,9 +4,15 @@ require 'playground_book_lint/manifest_linter'
 module PlaygroundBookLint
   # A linter for verifying the contents of a page's Manifest.plist
   class PageManifestLinter < ManifestLinter
+    SUPPORTED_LIVE_VIEW_MODES = ['VisibleByDefault', 'HiddenByDefault']
+
     def lint
       super()
-      # TODO: Check for valid LiveViewMode values.
+
+      live_view_mode = manifest_plist_contents['LiveViewMode']
+      unless live_view_mode.nil?
+        fail_lint "Unsopported LiveViewMoode '#{live_view_mode}'" unless SUPPORTED_LIVE_VIEW_MODES.include? live_view_mode
+      end
     end
   end
 end

--- a/spec/playground_book_lint/page_manifest_linter_spec.rb
+++ b/spec/playground_book_lint/page_manifest_linter_spec.rb
@@ -5,7 +5,7 @@ module PlaygroundBookLint
     include FakeFS::SpecHelpers
     let(:page_manifest_linter) { PageManifestLinter.new }
 
-    it 'does not fail' do
+    it 'given a valid manifest does not fail' do
       # TODO: We're not checking optional values yet, more tests to come.
       # See page_manifest_linter.rb and https://github.com/ashfurrow/playground-book-lint/issues/3 for details.
 
@@ -13,6 +13,30 @@ module PlaygroundBookLint
         plist = { 'Name' => 'Test Page' }.to_plist
         File.open('Manifest.plist', 'w') { |f| f.write(plist) }
         expect { page_manifest_linter.lint }.to_not raise_error
+      end
+    end
+
+    describe 'context given a live view mode' do
+      it 'succeeds with valid values' do
+        FakeFS do
+          plist = {
+            'Name' => 'Test Page',
+            'LiveViewMode' => 'HiddenByDefault'
+          }.to_plist
+          File.open('Manifest.plist', 'w') { |f| f.write(plist) }
+          expect { page_manifest_linter.lint }.to_not raise_error
+        end
+      end
+
+      it 'fails with invalid values' do
+        FakeFS do
+          plist = {
+            'Name' => 'Test Page',
+            'LiveViewMode' => 'UnsupportedViewMode'
+          }.to_plist
+          File.open('Manifest.plist', 'w') { |f| f.write(plist) }
+          expect { page_manifest_linter.lint }.to raise_error(SystemExit)
+        end
       end
     end
   end


### PR DESCRIPTION
This addresses #3 and makes sure the value of `LiveViewMode` is a valid value. Looking at the WWDC session and Apple's own playgrounds, the only possible values for this key are `VisibleByDefault` and  `HiddenByDefault`.